### PR TITLE
Connection pool 생성

### DIFF
--- a/web/modules/pool.js
+++ b/web/modules/pool.js
@@ -1,0 +1,61 @@
+const poolPromise = require('../config/database');
+
+module.exports = { 
+    queryParam: async (query) => {
+        return new Promise ( async (resolve, reject) => {
+            try {
+                const pool = await poolPromise;
+                const connection = await pool.getConnection();
+                try {
+                    const result = await connection.query(query);
+                    pool.releaseConnection(connection);
+                    resolve(result);
+                } catch (err) {
+                    pool.releaseConnection(connection);
+                    reject(err);
+                }
+            } catch (err) {
+                reject(err);
+            }
+        });
+    },
+    queryParamArr: async (query, value) => {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const pool = await poolPromise;
+                const connection = await pool.getConnection();
+                try {
+                    const result = await connection.query(query, value);
+                    pool.releaseConnection(connection);
+                    resolve(result);
+                } catch (err) {
+                    pool.releaseConnection(connection);
+                    reject(err);
+                }
+            } catch (err) {
+                reject(err);
+            }
+        });
+    },
+    Transaction: async (...args) => {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const pool = await poolPromise;
+                const connection = await pool.getConnection();
+                try {
+                    await connection.beginTransaction();
+                    args.forEach(async (it) => await it(connection));
+                    await connection.commit();
+                    pool.releaseConnection(connection);
+                    resolve(result);
+                } catch (err) {
+                    await connection.rollback()
+                    pool.releaseConnection(connection);
+                    reject(err);
+                }
+            } catch (err) {
+                reject(err);
+            }
+        });
+    }
+}


### PR DESCRIPTION
![images-gwon713-post-c60091a1-ec24-49bc-9fd4-9698a549f0c2-캡처3](https://user-images.githubusercontent.com/72901045/181741374-a82f8655-ea21-4884-bab6-80edf18e1685.PNG)
Connection pool의 기본 구조로 클라이언트가 DB에 직접 요청해 쿼리문을 보낼 때마다 connection을 생성하지 않고 하나의 pool을 만든 후 지정한 수만큼 connection을 담고 요청이 들어올 때마다 빌려주고 반환받는다. 
어쩌다보니 한 문장이 엄청 길어졌는데 간략히 말하자면 기존의 비효율적인 구조를 개선한 것이다,,,... 이렇게 되면 동시접속자 수가 갑자기 늘어나도 에러가 발생하지 않는다고 한다. 
Connection pool 관련 더 자세한 이야기가 읽고 싶다면 다음 링크 [DBCP Connection Pool 연결 대기 지연 현상](https://engineering-skcc.github.io/cloud/tomcat/apache/DB-Pool-For-Event/) , [Commons DBCP 이해하기](https://d2.naver.com/helloworld/5102792) 를 참고하시길..!
<br/>

+) 사실 너무 소소하게 PR하는게 아닌가,,, 싶은데 이게 권장하는 거라며?? 충돌 일어났을 때 체크포인트 삼을 수 있다고 ^ㅡ^...!!! 그래서 용기를 얻고 간단하게 날려볼게,,~