### PR TITLE
판례 상세 내용 보기 수정과 코드 refactoring

### DIFF
--- a/web/controller/db.js
+++ b/web/controller/db.js
@@ -11,12 +11,12 @@ module.exports = {
         }
     },
 
-    getCaseAll: async(req,res) =>{
-        const allcase = await Case.getCaseAll();
-        if(!allcase){
+    getCaseDetail: async(req,res) =>{
+        const detailcase = await Case.getCaseDetail();
+        if(!detailcase){
             res.send("Error");
         }else{
-            res.send(allcase);
+            res.send(detailcase);
         }
     },
 }

--- a/web/controller/similar.js
+++ b/web/controller/similar.js
@@ -7,7 +7,7 @@ const iconv = require('iconv-lite');
 
 module.exports= {
 	//similar: async function(req, res, next, err){
-		similar:function(data){
+		get_similarity:function(data){
 			return new Promise(async function(resolve, reject) {
 			setTimeout(function(){	
 				const python = spawn('python', ['search_run.py', data]);

--- a/web/controller/split.js
+++ b/web/controller/split.js
@@ -1,11 +1,7 @@
-var string = ["{'판례일련번호' : {'2941':150733,'18688': 150633,'12345': 77133},유사도:{'2941' : 56.6,'18688':50.0,'12345':50.1}\r\n"]
-//var string = [{"사건명":"차량인도가처분결정에대한재항고","판례일련번호":"150633","선고일자":"1962-01-18","사건 종류명":"민사"},{"사건명":"면직처분취소","판례일련번호":"150733","선고일자":"1962-02-15","사건종류명":"일반행정"},{"사건명":"급수료청구사건","판례일련번호":"77133","선고일자":"1962-11-30","사건종류명":"민사"}]
-var string = JSON.stringify(string);
- 
-
 module.exports = {
     sim : function(string){
            //1.공백제거
+           string = JSON.stringify(string);
             string = string.replace(/\s/g,"")
             //,
             var reg = /[\{\}\[\]\/?;|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi
@@ -34,55 +30,5 @@ module.exports = {
 
             return data;
         },
-        
-        cases : function(string){
-            var string = JSON.stringify(string);
-            console.log("1.기본 string :\n", string)
-            string = string.replace(/\s/g,"")
-                       string = string.split(/},/g)
-                       index = string.length
-                       var string = JSON.stringify(string);
-            
-                       var reg = /[\{\}\[\]\/?;|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi 
-                        if(reg.test(string)){
-                            string = string.replace(reg, "");    
-                        }
-                        console.log("2.변환 후 string : ", string)
-                        console.log("string 길이 : " , )
-                        for(i = 0; i<index ; i++){
-                        
-                        string = string.replace("사건명:", "");
-                        string = string.replace("판례일련번호:", "");
-                        string = string.replace("사건종류명:", "");
-                        string = string.replace("선고일자:", "");
-                        
-                        }
-                      
-                        console.log("3.변환 후 string : ", string)
-                       
-                        string = string.split(/,/g)
-                        console.log("4.변환 후 string : ", string)
-                        const cases = []
-                        caseTitle = []
-                        caseNumber = []
-                        caseType = []
-                        caseDate = []
-                        for(i=0,j=0;i<string.length;i = i + 4,j++){
-                            caseTitle[j] = string[i]
-                            caseNumber[j] = string[i+1]
-                            caseType[j] = string[i+2]
-                            caseDate[j] = string[i+3]
-            
-                        }
-                        
-                        console.log(caseTitle.length)
-                        for(i=0;i<caseTitle.length; i++){
-                           
-                           cases.push([caseTitle[i],caseNumber[i],caseType[i],caseDate[i]])
-                        }
-                        console.log("5. 최종 string : ",cases)
-            
-            return cases
-        }
-
+      
 }

--- a/web/models/cases_info.js
+++ b/web/models/cases_info.js
@@ -2,101 +2,85 @@ const similarity = require('../controller/similar.js')
 const pool = require('../modules/pool.js');
 const upload = require('../controller/upload')
 const split = require('../controller/split');
-const table = 'case_info';
-
-
-
+const table = 'cases_info';
 //주석 제외 실행됨
 
 module.exports ={
-    getCaseSearch : async function(){
+    getCaseSearch : async function(request, response){
         try{
+            /*
+            1. spawn과 관련된 내용을 similar.js파일에서 처리
+            2. upload에 있는 spawn과 관련된 내용 삭제
+            3. upload에서는 업로드 된 파일을 받는 역할
+            4. upload에서 업로드 된 파일과 관련된 내용을 전역변수화(global.jsoncases)
+            5. upload에 getData라는 파일과 관련된 내용을 가져오는 함수 설정
+            6. cases_info에서 upload.getData를 불러 json형태로된 사건과 관련된 내용 가져옴
+            7. cases_info에서 similar파일 내의함수 similar를 사건과 관련된 내용을 이용하여 호출
+            8. similar에서 spawn 수행
+            9. similar에서 유사도 반환
+            10. 유사도 받은 후 sql실행
+            */     
+            //사건 내용을 가져온다.
+            case_contents = upload.getData();
             
-            //여기서 판례일련번호를 이용하여 필요한데이터를 가져온다.
+            
+            //similarity.similar에서 유사도와 판례일련번호 값을 가져온다.
+            //similar.js내의 함수 similar를 similarity로 바꾸어주었다.
+            var sim_result = await similarity.get_similarity(case_contents)
            
-           /*
-           1. spawn과 관련된 내용을 similar.js파일에서 처리
-           2. upload에 있는 spawn과 관련된 내용 삭제
-           3. upload에서는 업로드 된 파일을 받는 역할
-           4. upload에서 업로드 된 파일과 관련된 내용을 전역변수화(global.jsoncases)
-           5. upload에 getData라는 파일과 관련된 내용을 가져오는 함수 설정
-           6. cases_info에서 upload.getData를 불러 json형태로된 사건과 관련된 내용 가져옴
-           7. cases_info에서 similar파일 내의함수 similar를 사건과 관련된 내용을 이용하여 호출
-           8. similar에서 spawn 수행
-           9. similar에서 유사도 반환
-           10. 유사도 받은 후 sql실행
-           */               
-          str = upload.getData();
-          //console.log("getData에서 가져오는 값 : ", str)
-          
-          
-          //similarity.similar에서 유사도와 판례일련번호 값을 가져온다.
-          var sim_result = await similarity.similar(str)
-          var sim_result = JSON.stringify(sim_result);
-          console.log("유사도 : ", sim_result)
-                             
-            
-          //split내에서 판례일련번호와 유사도 순으로 분리시켜준다.
-          //split.sim()내의 매개변수로는 similarity.similar에서 구해진 결과를 넣어야한다.
-          var splitData = await split.sim(sim_result)
-          number = splitData[0]
-          sim = splitData[1]
-          console.log("판례일련번호 : ", number, "유사도 : ", sim);
+            //split내에서 판례일련번호와 유사도 순으로 분리시켜준다.
+            //분리된 내용을 number와 sim에 넣는다.(number에는 판례일련번호, sim에는 유사도)
+            //split.sim()내의 매개변수로는 similarity.similarity에서 구해진 결과를 넣어야한다.
+            var splitData = await split.sim(sim_result)
+            number = splitData[0]
+            sim = splitData[1]
 
-            //유사도와 판례일련번호 분할   
-            /*     
-            var string = "{'판례일련번호' : {'2941':150733,'18688': 150633,'12345': 77133},유사도:{'2941' : 56.6,'18688':50.0,'12345':50.1}"
-                    
-            console.log("원래 string : ", string)
-            string = string.replace(/\s/g,"")
-            console.log("1. 제거후string : ", string);
-            var reg = /[\{\}\[\]\/?;|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi
-                    
-                    
-            if(reg.test(string)){
-                string = string.replace(reg, "");    
-            }
-            console.log("2. 제거후string : ", string);
-            string = string.replace("판례일련번호:","")
-            string = string.replace("유사도:","")
-            console.log("3. 제거후string : ", string);
-            
-            string = string.replace(/[0-9]*:/g,"")
-            string = string.split(/,/g)
+            //제대로 들어가는지 확인
+            console.log("판례일련번호 : ", number, "유사도 : ", sim);
             
             
-            console.log("4. 제거후string : ", string);
-            
-            number = [];
-            sim = [];
-            for(i=0;i<string.length/2;i++){
-                number[i] = string[i] 
-                sim[i] = string[i+string.length/2]
-            }
-            console.log("판례일련번호 : ", number)
-            console.log("유사도 : ", sim)
-            */
-            //여기까지가 판례일련번호와 유사도 분할 코드
-
             //판례일련번호로 데이터베이스 select문 실행한다.
-            const sql = `select 사건명,판례일련번호,선고일자,사건종류명  from ${table} where 판례일련번호 IN ( ${number} )`
+            //판례일련번호 in(number)를 사용할 거면 판례일련번호의 형태가 int형이어야 한다.
+            //만약 판례일련번호가 string 형태라면 판례일련번호 in ( number)구분이 오류가 나 실행 되지 않는다.
+            const sql = `select 사건명,판례일련번호,선고일자,사건종류명 from ${table} where 판례일련번호 IN( ${number} );`
             var result  = await pool.queryParam(sql);
-            var jsonStr = JSON.stringify(result);
             
-            sim_index = sim.length;
-            sim_index = JSON.stringify(sim_index);           
+            sim_index = sim.length; // 유사도의 길이를 확인(json형태)
+            sim_index = JSON.stringify(sim_index); // json형태의 sim_index를 string형태로 변환
+ 
+            //json형태의 result에 유사도를 추가하여 유사도 항목에 sim을 넣는다(sim : 유사도)
             for(i = 0; i < Number(sim_index) ; i++)
             result[i].유사도 = sim[i]
-
-            jsonStr = JSON.stringify(result);
-
-            console.log("result : ", result);
-
+            
+            //json형태로 반환해준다.
             return result
             
         } catch(err){
             console.log(err)
             throw err
         }
+    },
+    
+
+    getCaseDetail : async function(){
+        try{
+            
+            /*
+            1. getCaseAll -> getCaseDetail
+            2. 웹(프엔)에서 다운로드 버튼을 클릭하면 해당 행의 판례일련번호를 받아옴 -> sql 구문 실행
+            3. 판례 상세보기에 ++(유사도)도 함께 보여주는 게 좋을ㄲ/ㅏ?
+            */
+
+            casenumber = req.body.case;
+
+            const sql = `select * from ${table} where 판례일련번호 IN ( ${casenumber} )`
+            var result  = await pool.queryParam(sql);
+
+            return result
+        
+        } catch(err){
+            console.log(err)
+            throw err
+        }
     }
-    }
+}

--- a/web/routes/board.js
+++ b/web/routes/board.js
@@ -5,6 +5,6 @@ const CaseController = require('../controller/db')
 
 //html 파일 읽기
 router.get('/board', CaseController.getCaseSearch)
-router.get('/board/:casenumber', CaseController.getCaseAll)
+router.get('/board/:casenumber', CaseController.getCaseDetail)
 
 module.exports = router;


### PR DESCRIPTION
### 수정 내용
- `split.js`랑 `cases_info.js`에 반영 안된 부분 push
- 기존 getCaseAll을 `getCaseDetail`로 함수명을 고침(더 좋은 작명이 있다면 의견 구합니다)
- 상세 내용 보기에 필요한 대략적인 틀 수정

<br/>

### 물어보고 싶은 것

1. 판례 상세 보기에 유사도를 포함시키는 게 좋을까?
2. 변수 함수 다 포함해서 이걸 단수로 할 지 아님 복수로 할지 ,,,
    - 단수(ex. `case`): 글자수를 하나라도 줄일 수 있다 ^ㅡ^
    - 복수(ex. `cases`): 기존 `cases_info.js` 스크립트가 있어서 나름의 통일감을 줄 수 있음 ㅋㅋ....~